### PR TITLE
Handle value append mode in addProtoField

### DIFF
--- a/wirebaitlib/dissector/TreeItem.lua
+++ b/wirebaitlib/dissector/TreeItem.lua
@@ -132,11 +132,18 @@ function TreeItemClass.new(protofield_or_buffer, buffer, parent)
         assert(buffer or value, "Bug in this function, buffer and value cannot be both nil!");
 
         local child_tree = TreeItemClass.new(protofield, buffer, tree);
-        if texts then --texts override the value displayed in the tree including the header defined in the protofield
-            child_tree.m_text = tostring(prefix(tree.m_depth) .. table.concat(texts, " "));
-        else
-            local printed_value = tostring(value or protofield:getDisplayValueFromBuffer(buffer)) -- buffer(0, size):bytes()
-            child_tree.m_text = tostring(prefix(tree.m_depth) .. protofield:getMaskPrefix(buffer) .. protofield.m_name .. ": " .. printed_value); --TODO review the or buffer:len
+        local printed_value = tostring(value or protofield:getDisplayValueFromBuffer(buffer)) -- buffer(0, size):bytes()
+        child_tree.m_text = tostring(prefix(tree.m_depth) .. protofield:getMaskPrefix(buffer) .. protofield.m_name .. ": " .. printed_value); --TODO review the or buffer:len
+        if texts then --texts overrides or appends to the value displayed in the tree including the header defined in the protofield
+            local value_text = {};
+            for k, v in pairs(texts) do
+                  table.insert(value_text, v) -- skip and eliminate nil values
+            end
+            if texts[1] then -- override mode
+                child_tree.m_text = tostring(prefix(tree.m_depth) .. table.concat(value_text, " "));
+            else -- append mode if texts[1] is nil
+                child_tree.m_text = child_tree.m_text .. " ".. table.concat(value_text, " ");
+            end
         end
         return child_tree;
     end


### PR DESCRIPTION
 - Wireshark Wiki LuaAPI/TreeItem page says of :add's text arguments:

> Additional strings (or numbers) to be appended to the value text.
   If multiple text arguments are provided, they are all concatenated
   with a space delimiter to form a single string. Any `text` arguments
   that are not strings or numbers are ignored (including `nil`)."

 > **If `text1` is a string type, all `text` arguments (including `text1`)
   overwrite the full text of the `TreeItem` rather than appending to the
   existing text. So, use `nil` for `text1` to append the remaining
   arguments to the value text.** (By design? A bug turned feature?)"

 - This commit fixes two problems:
    + `nil`s should be ignored, but weren't being skipped
    + append vs overwrite when `text1` is `nil`